### PR TITLE
Logging of mocked requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,17 @@ apiMocker('/api', {
 
 With that option, you can mock only specific urls simply.
 
+## Logging
+
+If you want to see which requests are being mocked, set the `verbose` option either to `true` or provide your own function.
+
+```js
+apiMocker('/api', {
+  target: 'mocks/api',
+  verbose: ({ req, filePath, fileType }) => console.log(`Mocking endpoint ${req.originalUrl} using ${filePath}.${fileType}.`)
+});
+```
+
 <!-- Definitions -->
 
 [connect]: https://github.com/senchalabs/connect

--- a/api-mocker.js
+++ b/api-mocker.js
@@ -23,6 +23,7 @@ var fs = require('fs');
 var path = require('path');
 var nodeUrl = require('url');
 var bodyParser = require('body-parser');
+var chalk = require('chalk');
 
 function trimSlashes(text) {
   return text.replace(/\/$/, '').replace(/^\//, '');
@@ -30,6 +31,15 @@ function trimSlashes(text) {
 
 function escapeRegExp(str) {
   return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+}
+
+function logger(params) {
+  console.log(
+    chalk.bgYellow.black('api-mocker') + ' ' +
+    chalk.green(params.req.method.toUpperCase()) + ' ' + 
+    chalk.blue(params.req.originalUrl) + ' => ' +
+    chalk.cyan(params.filePath + '.' + params.fileType)
+  );
 }
 
 /**
@@ -96,6 +106,7 @@ module.exports = function (urlRoot, pathRoot) {
       var filePath = path.resolve(targetFolder, req.method);
 
       if (fs.existsSync(filePath + '.js')) {
+        logger({ req: req, filePath: filePath, fileType: 'js' })
         delete require.cache[require.resolve(filePath + '.js')];
         var customMiddleware = require(filePath + '.js');
         if (requestParams) {
@@ -113,6 +124,7 @@ module.exports = function (urlRoot, pathRoot) {
         };
 
         if (fs.existsSync(filePath + '.' + fileType)) {
+          logger({ req: req, filePath: filePath, fileType: fileType })
           var buf = fs.readFileSync(filePath + '.' + fileType);
 
           res.setHeader('Content-Type', 'application/' + fileType);

--- a/api-mocker.js
+++ b/api-mocker.js
@@ -33,13 +33,21 @@ function escapeRegExp(str) {
   return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
 }
 
-function logger(params) {
+function defaultLogger(params) {
   console.log(
     chalk.bgYellow.black('api-mocker') + ' ' +
     chalk.green(params.req.method.toUpperCase()) + ' ' + 
     chalk.blue(params.req.originalUrl) + ' => ' +
     chalk.cyan(params.filePath + '.' + params.fileType)
   );
+}
+
+function logger(params) {
+  if (params.config.verbose === true) {
+    defaultLogger(params)
+  } else if (typeof params.config.verbose === 'function') {
+    params.config.verbose(params)
+  }
 }
 
 /**
@@ -106,7 +114,7 @@ module.exports = function (urlRoot, pathRoot) {
       var filePath = path.resolve(targetFolder, req.method);
 
       if (fs.existsSync(filePath + '.js')) {
-        logger({ req: req, filePath: filePath, fileType: 'js' })
+        logger({ req: req, filePath: filePath, fileType: 'js', config: config })
         delete require.cache[require.resolve(filePath + '.js')];
         var customMiddleware = require(filePath + '.js');
         if (requestParams) {
@@ -124,7 +132,7 @@ module.exports = function (urlRoot, pathRoot) {
         };
 
         if (fs.existsSync(filePath + '.' + fileType)) {
-          logger({ req: req, filePath: filePath, fileType: fileType })
+          logger({ req: req, filePath: filePath, fileType: fileType, config: config })
           var buf = fs.readFileSync(filePath + '.' + fileType);
 
           res.setHeader('Content-Type', 'application/' + fileType);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-api-mocker",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12,6 +12,14 @@
       "requires": {
         "mime-types": "2.1.17",
         "negotiator": "0.6.1"
+      }
+    },
+    "ansi-styles": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "requires": {
+        "color-convert": "1.9.1"
       }
     },
     "array-flatten": {
@@ -69,6 +77,44 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "chalk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "requires": {
+        "ansi-styles": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "4.5.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.5",
@@ -186,8 +232,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "etag": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "supertest": "^3.0.0"
   },
   "dependencies": {
-    "body-parser": "^1.18.2"
+    "body-parser": "^1.18.2",
+    "chalk": "^2.3.0"
   }
 }


### PR DESCRIPTION
Hi!
We've started using you lib at Ataccama and came up with a nifty little feature - logging of what request have been mocked by middleware, so it would be more transparent. It looks like this:

![image](https://user-images.githubusercontent.com/12248365/35679880-ea7d1bce-0758-11e8-88f3-27822c2ef15a.png)

I think that it will remove the guesswork of "did this get passed to API?" and "does our mock layer work?".