### PR TITLE
Unlocked usage of all parsers and options of `body-parser`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+install:
+  - npm install
 cache:
   directories:
     - ~/.npm

--- a/README.md
+++ b/README.md
@@ -422,6 +422,28 @@ apiMocker('/api', {
 
 With that option, you can mock only specific urls simply.
 
+## Body parser
+
+By default request body is parsed with help of [body-parser](https://github.com/expressjs/body-parser).
+Default configuration uses JSON parser, however you can modify it with help of `bodyParser` object.
+`bodyParser` object supports configuration of
+
+ - parser type via `type` setting. 
+ - parser options via `options` setting.
+
+Supported parsers and corresponding options can be found [here](https://github.com/expressjs/body-parser#bodyparserjsonoptions)
+
+Example belows configures usage of `text` parser for requests with `content-type=application/vnd.custom-type`
+```js
+apiMocker('/text', {
+  target: 'test/mocks',
+  bodyParser: {
+    type: 'text',
+    options: { type: 'application/vnd.custom-type' }
+  }
+})
+```
+
 ## Logging
 
 If you want to see which requests are being mocked, set the `verbose` option either to `true` or provide your own function.

--- a/index.js
+++ b/index.js
@@ -173,7 +173,13 @@ module.exports = function (urlRoot, pathRoot) {
         if (requestParams) {
           req.params = requestParams;
         }
-        bodyParser.json()(req, res, () => {
+        let bodyParserType = 'json';
+        let bodyParserOptions = {};
+        if(typeof config.bodyParser != "undefined"){
+          bodyParserType = config.bodyParser.type || 'json';
+          bodyParserOptions = config.bodyParser.options || {};
+        }
+        bodyParser[bodyParserType](bodyParserOptions)(req, res, () => {
           if (typeof customMiddleware === 'function') {
             customMiddleware = [customMiddleware];
           }

--- a/test/api-mocker.spec.js
+++ b/test/api-mocker.spec.js
@@ -46,6 +46,13 @@ app.use(apiMocker('/dyn', {
   target: 'test/mocks',
   type: 'auto'
 }));
+app.use(apiMocker('/text', {
+  target: 'test/mocks',
+  bodyParser: {
+    type: 'text',
+    options: { type: 'application/vnd.custom-type' }
+  }
+}));
 
 describe('Simple configuration with baseUrl', () => {
   it('responds for simple GET request', (done) => {
@@ -241,6 +248,15 @@ describe('Handling request body', () => {
       .expect({
         name: 'A name'
       }, done);
+  });
+
+  it('should work with request body raw', (done) => {
+    request(app)
+      .post('/text/bodyParser')
+      .set('Content-Type', 'application/vnd.custom-type')
+      .send('plain text')
+      .expect(201)
+      .expect('plain text', done);
   });
 
   it('shouldnt break to capability of reading raw request body', (done) => {

--- a/test/mocks/bodyParser/POST.js
+++ b/test/mocks/bodyParser/POST.js
@@ -1,0 +1,3 @@
+module.exports = function (req, res) {
+  res.status(201).send(req.body);
+};


### PR DESCRIPTION
Since `body-parser` is default go to tool for parsing request body, it makes sense to unlock its full power with support of all available parsers and options.